### PR TITLE
Create missions basic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ In this task, we workie with the real live data from the SpaceX API. The task is
 - Twitter: [IrotoriB](https://twitter.com/IrotoriB)
 - LinkedIn: [baroka](www.linkedin.com/in/baroka)
 
-👥 **Co Author : **
-- GitHub: [baroka-wp](https://github.com/Baroka-wp)
-- Twitter: [IrotoriB](https://twitter.com/IrotoriB)
-- LinkedIn: [baroka](www.linkedin.com/in/baroka)
+👥 **Co Author : Lembani Sakala**
+
+- GitHub: [@lembani](https://github.com/lembani)
+- Twitter: [@lembani_](https://twitter.com/lembani_)
+- LinkedIn: [lembani-sakala-b58615109](https://linkedin.com/in/lembani-sakala)
 
 ## Install
 ### Run the project in your local machine

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,9 +1,36 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchMissions } from '../redux/missions/missionsReducer';
+import MissionCard from './pages/MissionCard';
 
-const Missions = () => (
-  <div>
-    <h2>MISSIONS</h2>
-  </div>
-);
+const Missions = () => {
+  const missions = useSelector((state) => state.missions);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, []);
+
+  return (
+    <div>
+      <h2>MISSIONS</h2>
+      <table>
+        <thead>
+          <th>Mission</th>
+          <th>Description</th>
+          <th>Status</th>
+          <th> </th>
+        </thead>
+        <tbody>
+          {
+              missions.map((mission) => (
+                <MissionCard key={mission.mission_id} mission={mission} />
+              ))
+            }
+        </tbody>
+      </table>
+    </div>
+  );
+};
 
 export default Missions;

--- a/src/components/pages/MissionCard.js
+++ b/src/components/pages/MissionCard.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const MissionCard = ({ mission }) => (
+  <tr>
+    <td>{mission.mission_name}</td>
+    <td>{mission.description}</td>
+    <td>Not a member</td>
+    <td><button type="button">Join Mission</button></td>
+  </tr>
+);
+
+MissionCard.propTypes = {
+  mission: PropTypes.shape({
+    mission_name: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
+};
+
+export default MissionCard;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,8 +1,10 @@
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import missionsReducer from './missions/missionsReducer';
 import rocketsReducer from './rockets/rocketsReducer';
 
 const rootReducer = combineReducers({
   rockets: rocketsReducer,
+  missions: missionsReducer,
 });
 
 const store = configureStore({ reducer: rootReducer });

--- a/src/redux/missions/missionsReducer.js
+++ b/src/redux/missions/missionsReducer.js
@@ -1,0 +1,33 @@
+import axios from 'axios';
+
+const GET_MISSIONS = 'space-travelers/redux/GET_MISSIONS';
+const url = 'https://api.spacexdata.com/v3/missions';
+
+const getMissions = (payload) => ({ type: GET_MISSIONS, payload });
+
+export const fetchMissions = () => async (dispatch) => {
+  const response = await axios.get(url);
+  const data = await response.data;
+  const missions = [];
+
+  data.forEach((mission) => {
+    missions.push({
+      mission_id: mission.mission_id,
+      mission_name: mission.mission_name,
+      description: mission.description,
+      reserved: false,
+    });
+  });
+  dispatch(getMissions(missions));
+};
+
+const missionsReducer = (state = [], action) => {
+  switch (action.type) {
+    case GET_MISSIONS:
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export default missionsReducer;


### PR DESCRIPTION
### This PR contains the `basic structure for Missions` and _fetching Mission data from an API_ via _AXIOS_ and _Displaying them_.

> Highlights:

- Add Missions reducer 
- Update configureStore
- Basic Structure for Missions
- Fetch mission data from API
- Display mission data
- Update ReadMe
